### PR TITLE
Add all regions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Research on Valorant's In-Game API, All of the Information I currently have are 
 | Europe | https://pd.EU.a.pvp.net/ |
 | Asia Pacific | https://pd.AP.a.pvp.net/ |
 | Korea | https://pd.KO.a.pvp.net/ |
+| Brazil | https://pd.BR.a.pvp.net/ |
+| Latin America | https://pd.LATAM.a.pvp.net/ |
 
 ## Authentication
 Each API Request requires 2 Headers for authentication.


### PR DESCRIPTION
Whilst porting [ValorantRankedPoints][] over to Node (for fun) I needed to figure the correct
URLs for the OCE region. That lead me to the official API docs, and [this issue].

[ValorantRankedPoints]:: https://github.com/RumbleMike/ValorantRankedPoints
[this issue]:  https://github.com/RiotGames/developer-relations/issues/394